### PR TITLE
Update mocha-jsdom versioning; fix test syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "expect": "^1.20.1",
     "jsdom": "^9.2.1",
     "mocha": "^2.5.3",
-    "mocha-jsdom": "^1.1.0",
+    "mocha-jsdom": "~1.1.0",
     "mocha-multi": "^0.9.0"
   }
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -6,13 +6,13 @@ const path = require('path')
 
 
 describe('index', () => {
-  
+
   jsdom({
     src: fs.readFileSync(path.resolve(__dirname, '..', 'index.js'), 'utf-8')
   })
-  
+
 
   it('runs', () => {
-    expect(true).to.be.true
+    expect(true).toBe.true
   })
 })


### PR DESCRIPTION
@cernanb update common mocha-jsdom version issue. Change `to.be` to `toBe` in only test  